### PR TITLE
drop KWindowSystem::isPlatformWayland() checks

### DIFF
--- a/console/console.cpp
+++ b/console/console.cpp
@@ -131,11 +131,7 @@ void Console::printJSONConfig()
 
 void Console::printSerializations()
 {
-    if (KWindowSystem::isPlatformWayland()) {
-        QFile file(QStandardPaths::writableLocation(QStandardPaths::ConfigLocation) + QLatin1String("/kwinoutputconfig.json"));
-        file.open(QFile::ReadOnly);
-        qDebug().noquote() << file.readAll();
-    } else {
+    {
         QString path = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) + QLatin1String("/kscreen/");
         qDebug() << "Configs in: " << path;
 

--- a/console/main.cpp
+++ b/console/main.cpp
@@ -1,3 +1,4 @@
+
 /*
     SPDX-FileCopyrightText: 2012 Alejandro Fiestas Olivares <afiestas@kde.org>
 
@@ -47,7 +48,7 @@ void configReceived(KScreen::ConfigOperation *op)
     } else if (command == QLatin1String("config")) {
         console->printSerializations();
     } else if (command == QLatin1String("bug")) {
-        if (!KWindowSystem::isPlatformWayland()) {
+        {
             QTextStream(stdout) << QStringLiteral("\n========================xrandr --verbose==========================\n");
             QProcess proc;
             proc.setProcessChannelMode(QProcess::MergedChannels);

--- a/osd/osd.cpp
+++ b/osd/osd.cpp
@@ -66,15 +66,7 @@ void Osd::showActionSelector()
         QMetaObject::invokeMethod(m_osdActionSelector->rootObject(), "moveRight");
     }
 
-    if (KWindowSystem::isPlatformWayland()) {
-        auto layerWindow = LayerShellQt::Window::get(m_osdActionSelector.get());
-        layerWindow->setScope(QStringLiteral("on-screen-display"));
-        layerWindow->setLayer(LayerShellQt::Window::LayerOverlay);
-        layerWindow->setAnchors({});
-        layerWindow->setKeyboardInteractivity(LayerShellQt::Window::KeyboardInteractivityOnDemand);
-        m_osdActionSelector->setScreen(screen);
-        m_osdActionSelector->setVisible(true);
-    } else {
+    {
         auto newGeometry = m_osdActionSelector->geometry();
         newGeometry.moveCenter(screen->geometry().center());
         KX11Extras::setState(m_osdActionSelector->winId(), NET::SkipPager | NET::SkipSwitcher | NET::SkipTaskbar);


### PR DESCRIPTION
Since we don't support Wayland anymore, those always evaluate to false, thus not needed at all.