### PR TITLE
drop WITH_X11 symbol

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,9 +75,6 @@ set_package_properties(WaylandProtocols PROPERTIES
     URL "https://gitlab.freedesktop.org/wayland/wayland-protocols/"
 )
 
-option(WITH_X11 "Enable X11 support" ON)
-
-if(WITH_X11)
     find_package(X11)
     set_package_properties(X11 PROPERTIES
         DESCRIPTION "X11 libraries"
@@ -87,7 +84,6 @@ if(WITH_X11)
     )
     find_package(X11_XCB REQUIRED)
     find_package(XCB REQUIRED COMPONENTS XCB ATOM)
-endif()
 
 configure_file(config-X11.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config-X11.h)
 

--- a/config-X11.h.cmake
+++ b/config-X11.h.cmake
@@ -1,2 +1,0 @@
-/* Define if you have X11 at all */
-#cmakedefine01 WITH_X11

--- a/kded/CMakeLists.txt
+++ b/kded/CMakeLists.txt
@@ -30,10 +30,7 @@ target_link_libraries(kscreen PRIVATE
                               KF6::XmlGui
 )
 
-if(WITH_X11)
-    target_link_libraries(kscreen PRIVATE X11::X11 X11::Xi X11::XCB XCB::ATOM)
-endif()
-
+target_link_libraries(kscreen PRIVATE X11::X11 X11::Xi X11::XCB XCB::ATOM)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/kscreen.json.in
                ${CMAKE_CURRENT_BINARY_DIR}/kscreen.json

--- a/kded/daemon.cpp
+++ b/kded/daemon.cpp
@@ -29,16 +29,13 @@
 #include <QTimer>
 #include <QTransform>
 
-#if WITH_X11
 #include <X11/Xatom.h>
 #include <X11/Xlib-xcb.h>
 #include <X11/extensions/XInput.h>
 #include <X11/extensions/XInput2.h>
-#endif
 
 K_PLUGIN_CLASS_WITH_JSON(KScreenDaemon, "kscreen.json")
 
-#if WITH_X11
 struct DeviceListDeleter {
     void operator()(XDeviceInfo *p)
     {
@@ -56,7 +53,6 @@ struct XDeleter {
         }
     }
 };
-#endif
 
 KScreenDaemon::KScreenDaemon(QObject *parent, const QList<QVariant> &)
     : KDEDModule(parent)
@@ -247,12 +243,9 @@ void KScreenDaemon::configChanged()
         connect(m_saveTimer, &QTimer::timeout, this, &KScreenDaemon::saveCurrentConfig);
     }
     m_saveTimer->start();
-#if WITH_X11
     alignX11TouchScreen();
-#endif
 }
 
-#if WITH_X11
 void KScreenDaemon::alignX11TouchScreen()
 {
     if (qGuiApp->platformName() != QStringLiteral("xcb")) {
@@ -403,7 +396,6 @@ void KScreenDaemon::alignX11TouchScreen()
         break;
     }
 }
-#endif
 
 void KScreenDaemon::saveCurrentConfig()
 {

--- a/kded/daemon.h
+++ b/kded/daemon.h
@@ -46,9 +46,7 @@ private:
     void applyIdealConfig();
     void configChanged();
     void saveCurrentConfig();
-#if WITH_X11
     void alignX11TouchScreen();
-#endif
     void lidClosedChanged(bool lidIsClosed);
     void disableLidOutput();
     void setMonitorForChanges(bool enabled);


### PR DESCRIPTION
It always has to be enabled, so that symbol isn't needed anymore.